### PR TITLE
AS-28 Default sorting for Resources

### DIFF
--- a/frontend/controllers/_resources_controller.rb
+++ b/frontend/controllers/_resources_controller.rb
@@ -4,10 +4,9 @@ require Rails.root.join('app/controllers/resources_controller')
 
 class ResourcesController < ApplicationController
 
-  DEFAULT_RES_INDEX_OPTS = {
-      'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'top_container_uri_u_sstr:id'],
-      'sort' => 'identifier asc',
-      'facet.mincount' => 1
-  }
+  def index
+    params["sort"] ||= "identifier asc"
+    @search_data = Search.for_type(session[:repo_id], params[:include_components]==="true" ? ["resource", "archival_object"] : "resource", params_for_backend_search.merge({"facet[]" => SearchResultData.RESOURCE_FACETS}))
+  end
 
 end

--- a/frontend/controllers/_resources_controller.rb
+++ b/frontend/controllers/_resources_controller.rb
@@ -1,0 +1,13 @@
+# override the default sort parameters for resources
+
+require Rails.root.join('app/controllers/resources_controller')
+
+class ResourcesController < ApplicationController
+
+  DEFAULT_RES_INDEX_OPTS = {
+      'resolve[]' => ['repository:id', 'resource:id@compact_resource', 'top_container_uri_u_sstr:id'],
+      'sort' => 'identifier asc',
+      'facet.mincount' => 1
+  }
+
+end


### PR DESCRIPTION
**JIRA Ticket**: [AS-28](https://jira.lib.utk.edu/browse/AS-28)

# What does this Pull Request do?
Overrides/adds a default sort for browsing Resources.

# What's new?
A `_resources_controller.rb` that overrides the default sorting for browse > resources.

# How should this be tested?
* Acquire this PR branch
* Either in your VM or your testing environment, load the PR files and restart the appropriate service.
* (assumption: you already have some test EADs ("Resources") in your testing environment) Browse your Resources and they should be sorted in ascending order. If you don't have any sample EADs, there are some in [the utk-archivesspace-vagrant](https://github.com/utkdigitalinitiatives/utk-archivesspace-vagrant/tree/master/aspace-example-eads) repository.

# Interested parties
@robert-patrick-waltz 
@DonRichards 