### PR TITLE
Resolve Small Caps Issue

### DIFF
--- a/public/assets/stylesheets/custom/css/custom.css
+++ b/public/assets/stylesheets/custom/css/custom.css
@@ -28,3 +28,9 @@ body {
     font-size: 18px;
     font-weight: 400;
     margin: -6px 0 0; }
+
+.span.title,
+.span.required,
+.emph.render-smcaps,
+.emph.render-boldsmcaps {
+  font-variant: unset !important; }

--- a/public/assets/stylesheets/custom/css/custom.css
+++ b/public/assets/stylesheets/custom/css/custom.css
@@ -29,8 +29,8 @@ body {
     font-weight: 400;
     margin: -6px 0 0; }
 
-.span.title,
-.span.required,
+span.title,
+span.required,
 .emph.render-smcaps,
 .emph.render-boldsmcaps {
   font-variant: unset !important; }

--- a/public/assets/stylesheets/custom/scss/custom.scss
+++ b/public/assets/stylesheets/custom/scss/custom.scss
@@ -36,3 +36,10 @@ body {
     margin: -6px 0 0;
   }
 }
+
+.span.title,
+.span.required,
+.emph.render-smcaps,
+.emph.render-boldsmcaps {
+  font-variant: unset !important;
+}

--- a/public/views/layouts/application.html.erb
+++ b/public/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 	<%= csrf_meta_tags %>
 	<script crossorigin src="https://unpkg.com/react@16/umd/react.production.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js"></script>
-    <link href="https://www.lib.utk.edu/assets/header/header.css" rel="stylesheet">
+    <script async src="https://www.lib.utk.edu/assets/utk-libraries-header.js"></script>
 <%# block cross-origin refer per https://go-to-hellman.blogspot.com/2015/06/protect-reader-privacy-with-referrer.html %>
 	<% if AppConfig[:pui_block_referrer] %>
 		<meta name="referrer" content="origin-when-cross-origin" />
@@ -81,7 +81,5 @@
 			</script>
 		<% end %>
 	<% end %>
-	<script type="text/javascript" src="https://www.lib.utk.edu/assets/header/header.js"></script>
-
 </body>
 </html>


### PR DESCRIPTION
# What does this Pull Request do?

Resolves the issue with font rendering on input group labels in ArchiveSpaces **Request** modal. The brand webfont of the UT does not have small-caps glyphs available and causes illegible strings.

# What's new?
Addition of a few `!important` CSS overrides on various selectors to the custom.css stylesheet. These overrides are rendering in place of the default application styles with `font-variant: small-caps;`, setting the computed style as `font-variant: unset !important;`

# How should this be tested?

* Test via docker build process on https://github.com/utkdigitalinitiatives/utk_archivesspace_docker
* Set branch to `small-caps`
* Click into a collection
* Click request
* Rendered **required** labels should be lowercase and legible.

# Additional Notes:
Additional changes were made to my routing for header assets. These are covered in 
commit [259673](https://github.com/utkdigitalinitiatives/utk-archivesspace-local/commit/02596735d6e93c8921d901e1a521d7f8b8928551). The blink issue noted in live testing has been resolved here: https://github.com/utkdigitalinitiatives/utk_library_assets/commit/9ae31281c5fb282e9d08d4b1e4f066ff0859de56

# Interested parties
@markpbaggett 