### PR TITLE
Address Special Collections request modal instruction updates

### DIFF
--- a/public/assets/stylesheets/custom/css/custom.css
+++ b/public/assets/stylesheets/custom/css/custom.css
@@ -29,6 +29,12 @@ body {
     font-weight: 400;
     margin: -6px 0 0; }
 
+span.title,
+span.required,
+.emph.render-smcaps,
+.emph.render-boldsmcaps {
+  font-variant: unset !important; }
+
 .request-additional-notes {
   font-size: 14px; }
   .request-additional-notes li {

--- a/public/assets/stylesheets/custom/css/custom.css
+++ b/public/assets/stylesheets/custom/css/custom.css
@@ -28,3 +28,11 @@ body {
     font-size: 18px;
     font-weight: 400;
     margin: -6px 0 0; }
+
+.request-additional-notes {
+  font-size: 14px; }
+  .request-additional-notes li {
+    font-size: 14px;
+    line-height: 1.5em; }
+    .request-additional-notes li.no-bullet {
+      list-style: none; }

--- a/public/assets/stylesheets/custom/scss/custom.scss
+++ b/public/assets/stylesheets/custom/scss/custom.scss
@@ -36,3 +36,16 @@ body {
     margin: -6px 0 0;
   }
 }
+
+.request-additional-notes {
+  font-size: 14px;
+
+  li {
+    font-size: 14px;
+    line-height: 1.5em;
+
+    &.no-bullet {
+      list-style: none;
+    }
+  }
+}

--- a/public/assets/stylesheets/custom/scss/custom.scss
+++ b/public/assets/stylesheets/custom/scss/custom.scss
@@ -37,6 +37,13 @@ body {
   }
 }
 
+span.title,
+span.required,
+.emph.render-smcaps,
+.emph.render-boldsmcaps {
+  font-variant: unset !important;
+}
+
 .request-additional-notes {
   font-size: 14px;
 

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -68,9 +68,9 @@ en:
     date: Anticipated arrival date
     note: Please include information listed below
     note_additional: |
+      <li><strong>Date of Expected Use:</strong> Special Collections will be open by appointment only from August 19 to November 24.  You must schedule a time to view the requested materials through the registration form on the <a href="https://www.lib.utk.edu/special">Special Collections home page</a>.</li>
+      <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester.</li>
       <li><strong>Phone number</strong></li>
-      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href="https://www.lib.utk.edu/special">lib.utk.edu/special</a>)</li>
-      <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
       <li><strong>Other Information</strong></li>
       <li class="no-bullet"><span>*</span>Please check your email for confirmation of this collection request.</li>
 

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -67,12 +67,7 @@ en:
     user_email: Your email address
     date: Anticipated arrival date
     note: Please include information listed below.
-    note_additional: >
-      <li><strong>Phone number</strong></li>
-      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href="https://www.lib.utk.edu/special">lib.utk.edu/special</a>)</li>
-      <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
-      <li><strong>Other Information</strong></li>
-      <li class="no-bullet"><span>*</span>Please check your email for confirmation of this collection request.</li>
+    note_additional: "<li><strong>Phone number</strong></li><li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href=\"https://www.lib.utk.edu/special\">lib.utk.edu/special</a>)</li><li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li><li><strong>Other Information</strong></li><li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>"
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request
     submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request.

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -69,10 +69,10 @@ en:
     note: Please include information listed below
     note_additional: |
       <li><strong>Phone number</strong></li>
-      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href=\"https://www.lib.utk.edu/special\">lib.utk.edu/special</a>)</li>
+      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href="https://www.lib.utk.edu/special">lib.utk.edu/special</a>)</li>
       <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
       <li><strong>Other Information</strong></li>
-      <li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>
+      <li class="no-bullet"><span>*</span>Please check your email for confirmation of this collection request.</li>
 
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -72,7 +72,7 @@ en:
       <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href=\"https://www.lib.utk.edu/special\">lib.utk.edu/special</a>)</li>
       <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
       <li><strong>Other Information</strong></li>
-      <li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>"
+      <li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>
 
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -66,8 +66,14 @@ en:
     user_name: Your name
     user_email: Your email address
     date: Anticipated arrival date
-    note: Please include information listed below.
-    note_additional: "<li><strong>Phone number</strong></li><li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href=\"https://www.lib.utk.edu/special\">lib.utk.edu/special</a>)</li><li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li><li><strong>Other Information</strong></li><li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>"
+    note: Please include information listed below
+    note_additional: |
+      <li><strong>Phone number</strong></li>
+      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href=\"https://www.lib.utk.edu/special\">lib.utk.edu/special</a>)</li>
+      <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
+      <li><strong>Other Information</strong></li>
+      <li class=\"no-bullet\"><span>*</span>Please check your email for confirmation of this collection request.</li>"
+
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request
     submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request.

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -66,13 +66,13 @@ en:
     user_name: Your name
     user_email: Your email address
     date: Anticipated arrival date
-    note: Please dire
+    note: Please include information listed below.
     note_additional: >
-      "Phone number:
-      Date of Expected Use: Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (lib.utk.edu/special)
-      Box Number Requested: *Please limit collection requests to 6 or less boxes total per requester
-      Other Information:
-      *Please check your email for confirmation of this collection request."
+      <li><strong>Phone number</strong></li>
+      <li><strong>Date of Expected Use:</strong> Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (<a href="https://www.lib.utk.edu/special">lib.utk.edu/special</a>)</li>
+      <li><strong>Box Number Requested:</strong> Please limit collection requests to 6 or less boxes total per requester</li>
+      <li><strong>Other Information</strong></li>
+      <li class="no-bullet"><span>*</span>Please check your email for confirmation of this collection request.</li>
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request
     submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request.

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -66,7 +66,13 @@ en:
     user_name: Your name
     user_email: Your email address
     date: Anticipated arrival date
-    note: Please specify the boxes you'd like to request (box numbers), the MS/AR/MPA number, and a phone number if you'd prefer to be contacted that way.
+    note: Please dire
+    note_additional: >
+      "Phone number:
+      Date of Expected Use: Currently, Special Collections is open by appointment only. You must schedule a time to view the requested materials through the registration form on the Special Collections home page (lib.utk.edu/special)
+      Box Number Requested: *Please limit collection requests to 6 or less boxes total per requester
+      Other Information:
+      *Please check your email for confirmation of this collection request."
     visit: "Submit a request to visit %{repo_name} to view <strong>%{archival_object}</strong>"
     submit: Submit Request
     submitted: Thank you, your request has been submitted.  You will soon receive an email with a copy of your request.

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= t('request.note_additional') %></div>
+    <ul class="request-additional-notes"><%= t('request.note_additional.html_safe') %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <div><%= t('request.note_additional') %></div>
+    <ul class="request-additional-notes"><%= t('request.note_additional') %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -28,12 +28,6 @@
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
     <ul class="request-additional-notes"><%= t('request.note_additional').html_safe %></ul>
-    <div class="form-group honeypot">
-      <span class="aria-hidden">
-        <%= label_tag :comment %>
-        <%= text_field_tag :comment, nil, tabindex: '-1', :class => 'form-control'%>
-      </span>
-    </div>
     <button type="submit" class="btn btn-primary action-btn noscript"><%= t('request.submit') %></button>
   </div>
 <% end %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,8 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= process_mixed_content(request.note_additional).html_safe %></div>
+    <ul class="request-additional-notes"><%= raw('request.note_additional') %></div>
+    <ul class="request-additional-notes"><%== 'request.note_additional' %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= raw('request.note_additional') %></div>
+    <ul class="request-additional-notes"><%= raw(request.note_additional) %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= t('request.note_additional.html_safe') %></div>
+    <ul class="request-additional-notes"><%= raw('request.note_additional') %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= raw(request.note_additional) %></div>
+    <ul class="request-additional-notes"><%= process_mixed_content('request.note_additional').html_safe %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -1,0 +1,39 @@
+<%= form_tag(app_prefix("fill_request"), method: 'post', :id => 'request_form') do %>
+  <%= render partial: 'shared/request_hiddens' %>
+  <div  id="request">
+    <div class="form-group required ">
+      <%= label_tag(:user_name, "#{t('request.user_name')} #{t('request.required')}" ,  :class => 'sr-only') %>
+      <div class="input-group">
+        <%= text_field_tag :user_name, nil, :placeholder => t('request.user_name'), :class => "form-control"%>
+        <div class="input-group-addon">
+          <span class="required aria-hidden"><%= t('request.required') %></span>
+        </div>
+      </div>
+    </div>
+    <div class="form-group required ">
+      <%= label_tag(:user_email, "#{t('request.user_email')} #{t('request.required')}",  :class => 'sr-only') %>
+      <div class="input-group">
+        <%= text_field_tag :user_email, nil, :type => 'email', :placeholder => t('request.user_email'), :class => 'form-control' %>
+        <div class="input-group-addon">
+          <span class="required aria-hidden"><%= t('request.required') %></span>
+        </div>
+      </div>
+    </div>
+    <div class="form-group ">
+      <%= label_tag(:date, t('request.date'),  :class => 'sr-only') %>
+      <%= text_field_tag :date, nil, :placeholder => t('request.date'), :class => 'form-control' %>
+    </div>
+    <div class="form-group ">
+      <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
+      <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
+    </div>
+    <div><%= t('request.note_additional') %></div>
+    <div class="form-group honeypot">
+      <span class="aria-hidden">
+        <%= label_tag :comment %>
+        <%= text_field_tag :comment, nil, tabindex: '-1', :class => 'form-control'%>
+      </span>
+    </div>
+    <button type="submit" class="btn btn-primary action-btn noscript"><%= t('request.submit') %></button>
+  </div>
+<% end %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,8 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= raw('request.note_additional') %></div>
-    <ul class="request-additional-notes"><%== 'request.note_additional' %></div>
+    <ul class="request-additional-notes"><%= t('request.note_additional').html_safe %></ul>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,7 +27,7 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes"><%= process_mixed_content('request.note_additional').html_safe %></div>
+    <ul class="request-additional-notes"><%= process_mixed_content(request.note_additional).html_safe %></div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>


### PR DESCRIPTION
# What does this Pull Request do?

Adds HTML formatted instructional text on the feedback modal per a Special Collections request. 

![image](https://user-images.githubusercontent.com/7376450/83305230-559e6400-a1ce-11ea-9287-1ba155a0fd4c.png)

# What's new?

* Adds **note_additional** key and html formatted list items
* Renders list items within an unordered list element on the request form template
* Styles list and list items to fit with neatly in request form modal
* Updates placeholder text on textarea to point user to instructional text below

# How should this be tested?

From your local docker instance of **utk_archivesspace_docker**
* Update the `.env` file to `BRANCH=request-updates`
* `docker-compose up --build -d`
* _Wait..._
* Look at any collection item
* Click request
* HTML formatted text will render in the modal

# Additional Notes:
This may not be the _best_ way to handle this. I saw conflicting methods to safely output HTML and eventually landed on the method used in the a145b6c commit. The show.html.erb file does something similar when rendering the welcome message on the homepage and I gave it go. My struggle to get to this point is why there are so many commits.

Also, tagging @CanOfBees just so he's aware this is coming. Suppose we can deploy on Monday.

# Interested parties
@markpbaggett @CanOfBees 
