### PR TITLE
Update view for request form to 2.5.1 w/ honeypot.

### DIFF
--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,6 +27,10 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
+    <div class="form-group honeypot">
+      <%= label_tag :comment %>
+      <%= text_field_tag :comment, nil, tabindex: '-1', :class => 'form-control'%>
+    </div>
     <ul class="request-additional-notes"><%= t('request.note_additional').html_safe %></ul>
     <button type="submit" class="btn btn-primary action-btn noscript"><%= t('request.submit') %></button>
   </div>


### PR DESCRIPTION
# What does this Pull Request do?

Updates the Request Form view to include the form element for honeypot that is normally available from the 2.5.1 public views. For more information on how this was sourced, see: https://github.com/archivesspace/archivesspace/blob/fce57d31036e819a8abb1fa0198823be798c779d/public/app/views/shared/_request_form.html.erb

# Additional Notes:

This would not have been an issue if we were not already overriding the Request Form for other purposes.


